### PR TITLE
OT-1731 fb camera input

### DIFF
--- a/keentools_facebuilder/camera_input.py
+++ b/keentools_facebuilder/camera_input.py
@@ -1,3 +1,4 @@
+import numpy as np
 from pykeentools import FaceBuilderCameraInputI
 
 from . import FBCameraItem
@@ -14,7 +15,7 @@ class FaceBuilderCameraInput(FaceBuilderCameraInputI):
         return self._camera_at(frame).get_projection_matrix()
 
     def view(self, frame):
-        return self._camera_at(frame).get_model_mat()
+        return np.eye(4)
 
     def image_size(self, frame):
         return self._camera_at(frame).get_image_size()

--- a/keentools_facebuilder/camera_input.py
+++ b/keentools_facebuilder/camera_input.py
@@ -1,15 +1,15 @@
+import keentools_facebuilder.blender_independent_packages.pykeentools_loader as pkt
 import numpy as np
-from pykeentools import FaceBuilderCameraInputI
 
-from . import FBCameraItem
-from .settings import get_main_settings, FBSceneSettings
+from .config import get_main_settings
 
 
-class FaceBuilderCameraInput(FaceBuilderCameraInputI):
+class FaceBuilderCameraInput(pkt.module().FaceBuilderCameraInputI):
     @staticmethod
-    def _camera_at(frame) -> FBCameraItem:
-        settings: FBSceneSettings = get_main_settings()
-        return settings.get_camera(settings.current_headnum, frame - 1)
+    def _camera_at(frame):
+        settings = get_main_settings()
+        head = settings.get_current_head()
+        return head.get_camera_by_keyframe(frame)
 
     def projection(self, frame):
         return self._camera_at(frame).get_projection_matrix()
@@ -18,4 +18,4 @@ class FaceBuilderCameraInput(FaceBuilderCameraInputI):
         return np.eye(4)
 
     def image_size(self, frame):
-        return self._camera_at(frame).get_image_size()
+        return self._camera_at(frame).get_oriented_image_size()

--- a/keentools_facebuilder/camera_input.py
+++ b/keentools_facebuilder/camera_input.py
@@ -1,0 +1,20 @@
+from pykeentools import FaceBuilderCameraInputI
+
+from . import FBCameraItem
+from .settings import get_main_settings, FBSceneSettings
+
+
+class FaceBuilderCameraInput(FaceBuilderCameraInputI):
+    @staticmethod
+    def _camera_at(frame) -> FBCameraItem:
+        settings: FBSceneSettings = get_main_settings()
+        return settings.get_camera(settings.current_headnum, frame - 1)
+
+    def projection(self, frame):
+        return self._camera_at(frame).get_projection_matrix()
+
+    def view(self, frame):
+        return self._camera_at(frame).get_model_mat()
+
+    def image_size(self, frame):
+        return self._camera_at(frame).get_image_size()

--- a/keentools_facebuilder/fbloader.py
+++ b/keentools_facebuilder/fbloader.py
@@ -173,9 +173,8 @@ class FBLoader:
         head = settings.get_head(headnum)
         cam = head.get_camera(camnum)
         headobj = head.headobj
-        camobj = cam.camobj
         kid = settings.get_keyframe(headnum, camnum)
-        cls.place_cameraobj(kid, camobj, headobj)
+        cls.place_camera(headnum, camnum)
         coords.update_head_mesh(settings, fb, head)
         # Load pins from model
         vp = cls.viewport()
@@ -196,13 +195,12 @@ class FBLoader:
         fb = cls.get_builder()
         settings = get_main_settings()
         head = settings.get_head(headnum)
-        headobj = head.headobj
 
-        for i, cam in enumerate(head.cameras):
-            if cam.has_pins():
-                kid = cam.get_keyframe()
-                cls.place_cameraobj(kid, cam.camobj, headobj)
-                cam.set_model_mat(fb.model_mat(kid))
+        for camnum, camera in enumerate(head.cameras):
+            if camera.has_pins():
+                cls.place_camera(headnum, camnum)
+                keyframe = camera.get_keyframe()
+                camera.set_model_mat(fb.model_mat(keyframe))
 
     @classmethod
     def update_all_camera_focals(cls, headnum):
@@ -229,16 +227,6 @@ class FBLoader:
         fb.set_centered_geo_keyframe(camera.get_keyframe())
 
     # --------------------
-    @classmethod
-    def place_cameraobj(cls, keyframe, camobj, headobj):
-        fb = cls.get_builder()
-        mat = coords.calc_model_mat(
-            fb.model_mat(keyframe),
-            headobj.matrix_world
-        )
-        if mat is not None:
-            camobj.matrix_world = mat
-
     @classmethod
     def set_camera_projection(cls, fl, sw, rx, ry,
                               near_clip=0.1, far_clip=1000.0):
@@ -390,13 +378,11 @@ class FBLoader:
         head = settings.get_head(headnum)
         cam = head.get_camera(camnum)
         kid = cam.get_keyframe()
-        camobj = cam.camobj
-        headobj = head.headobj
 
         cls.load_model_from_head(head)
         fb = cls.get_builder()
 
-        cls.place_cameraobj(kid, camobj, headobj)
+        cls.place_camera(headnum, camnum)
         # Load pins from model
         vp = cls.viewport()
         vp.pins().set_pins(vp.img_points(fb, kid))
@@ -410,8 +396,15 @@ class FBLoader:
         camera = head.get_camera(camnum)
         camobj = camera.camobj
         headobj = head.headobj
-        kid = settings.get_keyframe(headnum, camnum)
-        cls.place_cameraobj(kid, camobj, headobj)
+
+        fb = cls.get_builder()
+        keyframe = camera.get_keyframe()
+
+        mat = coords.calc_model_mat(
+            fb.model_mat(keyframe),
+            headobj.matrix_world)
+        if mat is not None:
+            camobj.matrix_world = mat
 
     @classmethod
     def load_pins(cls, headnum, camnum):

--- a/keentools_facebuilder/fbloader.py
+++ b/keentools_facebuilder/fbloader.py
@@ -22,7 +22,6 @@ import bpy
 import keentools_facebuilder.blender_independent_packages.pykeentools_loader as pkt
 import numpy as np
 
-from .camera_input import FaceBuilderCameraInput
 from .config import Config, get_main_settings
 from .utils import attrs, coords, cameras
 from .utils.exif_reader import update_image_groups, reload_all_camera_exif
@@ -41,6 +40,7 @@ class FBLoader:
 
     @classmethod
     def new_builder(cls):
+        from .camera_input import FaceBuilderCameraInput
         cls._camera_input = FaceBuilderCameraInput()
         cls._builder_instance = pkt.module().FaceBuilder(cls._camera_input)
         return cls._builder_instance

--- a/keentools_facebuilder/fbloader.py
+++ b/keentools_facebuilder/fbloader.py
@@ -22,6 +22,7 @@ import bpy
 import keentools_facebuilder.blender_independent_packages.pykeentools_loader as pkt
 import numpy as np
 
+from .camera_input import FaceBuilderCameraInput
 from .config import Config, get_main_settings
 from .utils import attrs, coords, cameras
 from .utils.exif_reader import update_image_groups, reload_all_camera_exif
@@ -40,7 +41,6 @@ class FBLoader:
 
     @classmethod
     def new_builder(cls):
-        from .camera_input import FaceBuilderCameraInput
         cls._camera_input = FaceBuilderCameraInput()
         cls._builder_instance = pkt.module().FaceBuilder(cls._camera_input)
         return cls._builder_instance

--- a/keentools_facebuilder/main_operator.py
+++ b/keentools_facebuilder/main_operator.py
@@ -17,25 +17,23 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import logging
-import math
 
 import bpy
-from bpy.types import Operator
 from bpy.props import (
     StringProperty,
     IntProperty,
 )
+from bpy.types import Operator
 
-from .utils import cameras, manipulate, materials, coords
-from .utils.manipulate import check_settings
-from .utils.attrs import get_obj_collection, safe_delete_collection
-from .fbloader import FBLoader
 from .config import get_main_settings, get_operators, Config
+from .fbloader import FBLoader
+from .utils import cameras, manipulate, materials, coords
+from .utils.attrs import get_obj_collection, safe_delete_collection
 from .utils.exif_reader import (read_exif_from_camera,
                                 update_exif_sizes_message,
-                                get_sensor_size_35mm_equivalent,
                                 copy_exif_parameters_from_camera_to_head,
                                 update_image_groups)
+from .utils.manipulate import check_settings
 
 
 class FB_OT_SelectHead(Operator):
@@ -574,7 +572,6 @@ class FB_OT_RotateImageCW(Operator):
         camera.rotate_background_image(1)
         camera.update_scene_frame_size()
         camera.update_background_image_scale()
-        FBLoader.update_camera_projection(self.headnum, self.camnum)
         FBLoader.fb_save(self.headnum, self.camnum)
         return {'FINISHED'}
 
@@ -597,7 +594,6 @@ class FB_OT_RotateImageCCW(Operator):
         camera.rotate_background_image(-1)
         camera.update_scene_frame_size()
         camera.update_background_image_scale()
-        FBLoader.update_camera_projection(self.headnum, self.camnum)
         FBLoader.fb_save(self.headnum, self.camnum)
         return {'FINISHED'}
 
@@ -620,7 +616,6 @@ class FB_OT_ResetImageRotation(Operator):
         camera.reset_background_image_rotation()
         camera.update_scene_frame_size()
         camera.update_background_image_scale()
-        FBLoader.update_camera_projection(self.headnum, self.camnum)
         FBLoader.fb_save(self.headnum, self.camnum)
         return {'FINISHED'}
 

--- a/keentools_facebuilder/movepin.py
+++ b/keentools_facebuilder/movepin.py
@@ -222,7 +222,6 @@ class FB_OT_MovePin(bpy.types.Operator):
         head = settings.get_head(headnum)
         headobj = head.headobj
         cam = head.get_camera(camnum)
-        camobj = cam.camobj
         kid = settings.get_keyframe(headnum, camnum)
 
         self._pin_drag(kid, context, mouse_x, mouse_y)
@@ -245,7 +244,7 @@ class FB_OT_MovePin(bpy.types.Operator):
         cam.set_model_mat(fb.model_mat(kid))
         # --------------
 
-        FBLoader.place_cameraobj(kid, camobj, headobj)
+        FBLoader.place_camera(headnum, camnum)
         coords.update_head_mesh(settings, fb, head)
 
         FBLoader.viewport().wireframer().init_geom_data(headobj)

--- a/keentools_facebuilder/pinmode.py
+++ b/keentools_facebuilder/pinmode.py
@@ -235,9 +235,7 @@ class FB_OT_PinMode(bpy.types.Operator):
                 kfnum = cam.get_keyframe()
                 logger.debug("UPDATE KEYFRAME: {}".format(kfnum))
                 if not fb.is_key_at(kfnum):
-                    fb.set_keyframe(kfnum, cam.get_model_mat(),
-                                    cam.get_projection_matrix(),
-                                    cam.get_oriented_image_size())
+                    fb.set_keyframe(kfnum, cam.get_model_mat())
 
         try:
             FBLoader.place_camera(settings.current_headnum,

--- a/keentools_facebuilder/settings.py
+++ b/keentools_facebuilder/settings.py
@@ -17,13 +17,11 @@
 # ##### END GPL LICENSE BLOCK #####
 
 
-import bpy
-import numpy as np
 import logging
 import math
 
-
-from . fbloader import FBLoader
+import bpy
+import numpy as np
 from bpy.props import (
     BoolProperty,
     IntProperty,
@@ -36,8 +34,10 @@ from bpy.props import (
     BoolVectorProperty
 )
 from bpy.types import PropertyGroup
+
+from .config import Config, get_main_settings, get_operators
+from .fbloader import FBLoader
 from .utils import coords
-from . config import Config, get_main_settings, get_operators
 from .utils.manipulate import what_is_state
 
 
@@ -106,8 +106,6 @@ def update_camera_focal(self, context):
 
     fb = FBLoader.get_builder()
     if fb.is_key_at(kid):
-        fb.update_projection_mat(kid, self.get_projection_matrix())
-        fb.update_image_size(kid, self.get_oriented_image_size())
         FBLoader.save_only(settings.current_headnum)
 
     if FBLoader.in_pin_drag() or self.auto_focal_estimation or \

--- a/keentools_facebuilder/settings.py
+++ b/keentools_facebuilder/settings.py
@@ -612,6 +612,12 @@ class FBHeadItem(PropertyGroup):
         else:
             return None
 
+    def get_camera_by_keyframe(self, keyframe):
+        for camera in self.cameras:
+            if camera.get_keyframe() == keyframe:
+                return camera
+        return None
+
     def get_last_camera(self):
         return self.get_camera(self.get_last_camnum())
 
@@ -839,6 +845,9 @@ class FBSceneSettings(PropertyGroup):
             return self.heads[headnum]
         else:
             return None
+
+    def get_current_head(self):
+        return self.heads[self.current_headnum]
 
     def get_camera(self, headnum, camnum):
         head = self.get_head(headnum)

--- a/keentools_facebuilder/utils/manipulate.py
+++ b/keentools_facebuilder/utils/manipulate.py
@@ -285,7 +285,7 @@ def reconstruct_by_head():
             auto_setup_camera_from_exif(camera)
 
             logger.debug("CAMERA CREATED {}".format(kid))
-            FBLoader.place_cameraobj(kid, camera.camobj, obj)
+            FBLoader.place_camera(headnum, i)
             camera.set_model_mat(fb.model_mat(kid))
             FBLoader.update_pins_count(headnum, i)
 


### PR DESCRIPTION
Here:
* use CameraInput in FaceBuilder's constructor
* drop deprecated methods like `update_projection`, `update_image_size`
* merge `place_camera` and `place_cameraobj` into a single method