### PR TITLE
CR-12 Pass 'Blender' as platform name to pykeentools APIs

### DIFF
--- a/keentools/facebuilder/fbloader.py
+++ b/keentools/facebuilder/fbloader.py
@@ -103,7 +103,7 @@ class FBLoader:
         _log.yellow(f'{cls.__name__} new_builder start')
         from .camera_input import FaceBuilderCameraInput
         cls._camera_input = FaceBuilderCameraInput()
-        cls._builder_instance = pkt_module().FaceBuilder(cls._camera_input)
+        cls._builder_instance = pkt_module().FaceBuilder(cls._camera_input, 'Blender')
         _log.output(f'{cls.__name__} new_builder end >>>')
         return cls._builder_instance
 

--- a/keentools/geotracker/utils/geotracker_acts.py
+++ b/keentools/geotracker/utils/geotracker_acts.py
@@ -1492,7 +1492,7 @@ def save_facs_as_csv_action(*, filepath: Optional[str] = None,
         facs_executor = pkt_module().FacsExecutor(neutral_geo, face_model_scale)
         facs_animation = facs_animation_object \
             if facs_animation_object is not None \
-            else pkt_module().FacsAnimation()
+            else pkt_module().FacsAnimation('Blender')
 
         if not use_tracked_only:
             frames = [x for x in range(from_frame, to_frame + 1)]
@@ -1531,7 +1531,7 @@ def save_facs_as_animation_action(*, from_frame: int = 1, to_frame: int = 1,
                                   obj: Object,
                                   new_action_name: str = 'ktARKit_anim') -> ActionStatus:
     _log.yellow(f'save_facs_as_csv_action start')
-    facs_animation = pkt_module().FacsAnimation()
+    facs_animation = pkt_module().FacsAnimation('Blender')
     save_status = save_facs_as_csv_action(filepath=None,
                                           from_frame=from_frame,
                                           to_frame=to_frame,

--- a/keentools/geotracker/utils/precalc_runner.py
+++ b/keentools/geotracker/utils/precalc_runner.py
@@ -135,7 +135,7 @@ def _run_test():
     frame_from = 5
     frame_to = 8
     runner = PrecalcRunner(
-        'tmp.precalc', test_w, test_h, frame_from, frame_to, pkt_module().GeoTracker.license_manager(), True)
+        'tmp.precalc', test_w, test_h, frame_from, frame_to, pkt_module().GeoTracker.license_manager('Blender'), True)
 
     while not runner.is_finished():
         print(runner.current_progress())

--- a/keentools/preferences/operators.py
+++ b/keentools/preferences/operators.py
@@ -48,11 +48,11 @@ _please_accept_eula = 'You need to accept our EULA before installation'
 
 def get_product_license_manager(product: int) -> Any:
     if product == ProductType.FACEBUILDER:
-        return pkt_module().FaceBuilder.license_manager()
+        return pkt_module().FaceBuilder.license_manager('Blender')
     elif product == ProductType.GEOTRACKER:
-        return pkt_module().GeoTracker.license_manager()
+        return pkt_module().GeoTracker.license_manager('Blender')
     elif product == ProductType.FACETRACKER:
-        return pkt_module().FaceTracker.license_manager()
+        return pkt_module().FaceTracker.license_manager('Blender')
     assert False, 'get_product_license_manager Wrong product ID'
 
 

--- a/keentools/utils/blendshapes.py
+++ b/keentools/utils/blendshapes.py
@@ -229,7 +229,7 @@ def restore_facs_blendshapes(obj: Object, scale: float,
 def load_csv_animation_to_blendshapes(obj: Object, filepath: str) -> Dict:
     try:
         _log.info(f'LOADING CSV FILE: {filepath}')
-        fan = pkt_module().FacsAnimation()
+        fan = pkt_module().FacsAnimation('Blender')
         read_facs, ignored_columns = fan.load_from_csv_file(filepath)
         facs_names = pkt_module().FacsExecutor.facs_names
     except pkt_module().FacsLoadingException as err:

--- a/keentools/utils/fb_wireframe_image.py
+++ b/keentools/utils/fb_wireframe_image.py
@@ -57,7 +57,7 @@ def _FBCameraInput_class() -> Any:
 def get_shadow_fb() -> Any:
     global _shadow_fb
     if _shadow_fb is None:
-        _shadow_fb = pkt_module().FaceBuilder(_FBCameraInput_class()())
+        _shadow_fb = pkt_module().FaceBuilder(_FBCameraInput_class()(), 'Blender')
     return _shadow_fb
 
 


### PR DESCRIPTION
The pykeentools FaceBuilder/GeoTracker/FaceTracker/FacsAnimation constructors and the license_manager() class accessors now require a platform_name argument. Pass 'Blender' at every call site:

- facebuilder/fbloader.py: FaceBuilder(...) ctor
- geotracker/utils/precalc_runner.py: GeoTracker.license_manager()
- geotracker/utils/geotracker_acts.py: FacsAnimation() ctor (x2)
- preferences/operators.py: FaceBuilder/GeoTracker/FaceTracker .license_manager() in get_product_license_manager
- utils/blendshapes.py: FacsAnimation() ctor
- utils/fb_wireframe_image.py: FaceBuilder(...) ctor